### PR TITLE
fix(ltosapi/client): clone `http.DefaultTransport` to preserve default HTTP transport settings

### DIFF
--- a/pkg/ltosapi/client.go
+++ b/pkg/ltosapi/client.go
@@ -42,14 +42,15 @@ func (c *Client) Target() string {
 
 // NewClient creates a new Meinberg LTOS API client
 func NewClient(baseURL string, authBasicUser, authBasicPass string, ignoreSSLVerify bool) *Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: ignoreSSLVerify}
+
 	return &Client{
 		baseURL:       baseURL,
 		authBasicUser: authBasicUser,
 		authBasicPass: authBasicPass,
 		httpClient: &http.Client{
-			Transport: &http.Transport{
-				TLSClientConfig: &tls.Config{InsecureSkipVerify: ignoreSSLVerify},
-			},
+			Transport: transport,
 		},
 	}
 }

--- a/pkg/ltosapi/client_test.go
+++ b/pkg/ltosapi/client_test.go
@@ -171,3 +171,47 @@ func TestFetchStatus_ContextCancelled(t *testing.T) {
 		t.Fatal("expected error when context is cancelled")
 	}
 }
+
+func TestNewClient_ClonesDefaultTransport(t *testing.T) {
+	client := NewClient("https://clock.example.com", "", "", true)
+
+	transport, ok := client.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.httpClient.Transport)
+	}
+
+	if transport.Proxy == nil {
+		t.Fatal("expected Proxy to be preserved from default transport")
+	}
+	if transport.DialContext == nil {
+		t.Fatal("expected DialContext to be preserved from default transport")
+	}
+	if !transport.ForceAttemptHTTP2 {
+		t.Fatal("expected ForceAttemptHTTP2 to be preserved from default transport")
+	}
+	if transport.TLSHandshakeTimeout == 0 {
+		t.Fatal("expected TLSHandshakeTimeout to be preserved from default transport")
+	}
+	if transport.TLSClientConfig == nil {
+		t.Fatal("expected TLSClientConfig to be set")
+	}
+	if !transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify=true")
+	}
+}
+
+func TestNewClient_DisablesInsecureSkipVerifyWhenRequested(t *testing.T) {
+	client := NewClient("https://clock.example.com", "", "", false)
+
+	transport, ok := client.httpClient.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("transport type = %T, want *http.Transport", client.httpClient.Transport)
+	}
+
+	if transport.TLSClientConfig == nil {
+		t.Fatal("expected TLSClientConfig to be set")
+	}
+	if transport.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify=false")
+	}
+}


### PR DESCRIPTION
Previously, `NewClient` constructed a bare `&http.Transport{}` with only `TLSClientConfig` set, discarding all of Go's default transport settings.

This drops proxy support (`ProxyFromEnvironment`), `DialContext`, HTTP/2 (`ForceAttemptHTTP2`), `MaxIdleConns`, `IdleConnTimeout`, and `TLSHandshakeTimeout` — all of which are configured in `http.DefaultTransport`.

Clone `http.DefaultTransport` and override only `TLSClientConfig.InsecureSkipVerify` to preserve standard behaviour while still honouring the `--ignore-ssl-verify` flag.

Closes #3.